### PR TITLE
fix: Use locked build to avoid build failures.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,7 +4,7 @@ FROM rust:latest as builder
 RUN apt update && apt install -y cmake
 
 COPY useful-crates /useful-crates
-RUN cargo install $(cat useful-crates)
+RUN cargo install --locked $(cat useful-crates)
 RUN rm /useful-crates
 
 

--- a/useful-crates
+++ b/useful-crates
@@ -10,7 +10,7 @@ du-dust
 hexyl
 bingrep
 git-delta
-gitui@0.24.3
+gitui
 ouch
 nu
 starship


### PR DESCRIPTION
Basically use the exact dependency version mentioned in the package's cargo.lock

